### PR TITLE
Have SwarmProtocol return messages

### DIFF
--- a/swarm-protocol/pom.xml
+++ b/swarm-protocol/pom.xml
@@ -27,18 +27,13 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.nhirakawa</groupId>
       <artifactId>immutable-style</artifactId>
-      <version>1.0</version>
+      <version>4.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/model/TimeoutResponses.java
+++ b/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/model/TimeoutResponses.java
@@ -1,0 +1,17 @@
+package com.github.nhirakawa.swarm.protocol.model;
+
+import com.github.nhirakawa.swarm.protocol.model.local.TimeoutResponse;
+
+public final class TimeoutResponses {
+
+  private static final TimeoutResponse EMPTY = TimeoutResponse.builder().build();
+
+  private TimeoutResponses() {
+    throw new IllegalStateException("Cannot instantiate TimeoutResponses");
+  }
+
+  public static TimeoutResponse empty() {
+    return EMPTY;
+  }
+
+}

--- a/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/model/local/PingAckResponseModel.java
+++ b/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/model/local/PingAckResponseModel.java
@@ -1,0 +1,15 @@
+package com.github.nhirakawa.swarm.protocol.model.local;
+
+import java.time.Instant;
+
+import org.immutables.value.Value;
+
+import com.github.nhirakawa.immutable.style.ImmutableStyle;
+
+@Value.Immutable
+@ImmutableStyle
+public interface PingAckResponseModel {
+
+  Instant getTimestamp();
+
+}

--- a/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/model/local/PingResponseModel.java
+++ b/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/model/local/PingResponseModel.java
@@ -1,0 +1,15 @@
+package com.github.nhirakawa.swarm.protocol.model.local;
+
+import org.immutables.value.Value;
+
+import com.github.nhirakawa.immutable.style.ImmutableStyle;
+import com.github.nhirakawa.swarm.protocol.config.SwarmNode;
+
+@Value.Immutable
+@ImmutableStyle
+public interface PingResponseModel {
+
+  SwarmNode getLocalSwarmNode();
+  SwarmNode getTargetNode();
+
+}

--- a/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/model/local/TimeoutResponseModel.java
+++ b/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/model/local/TimeoutResponseModel.java
@@ -1,0 +1,16 @@
+package com.github.nhirakawa.swarm.protocol.model.local;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+
+import com.github.nhirakawa.immutable.style.ImmutableStyle;
+import com.github.nhirakawa.swarm.protocol.config.SwarmNode;
+
+@Value.Immutable
+@ImmutableStyle
+public interface TimeoutResponseModel {
+
+  Optional<SwarmNode> getTargetNode();
+
+}

--- a/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/protocol/SwarmProtocol.java
+++ b/swarm-protocol/src/main/java/com/github/nhirakawa/swarm/protocol/protocol/SwarmProtocol.java
@@ -2,7 +2,6 @@ package com.github.nhirakawa.swarm.protocol.protocol;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -11,12 +10,15 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.nhirakawa.swarm.protocol.config.ConfigPath;
 import com.github.nhirakawa.swarm.protocol.config.SwarmNode;
 import com.github.nhirakawa.swarm.protocol.model.PingAckMessage;
 import com.github.nhirakawa.swarm.protocol.model.PingMessage;
 import com.github.nhirakawa.swarm.protocol.model.SwarmTimeoutMessage;
+import com.github.nhirakawa.swarm.protocol.model.TimeoutResponses;
+import com.github.nhirakawa.swarm.protocol.model.local.PingAckResponse;
+import com.github.nhirakawa.swarm.protocol.model.local.PingResponse;
+import com.github.nhirakawa.swarm.protocol.model.local.TimeoutResponse;
 import com.google.common.collect.ImmutableList;
 import com.typesafe.config.Config;
 
@@ -25,13 +27,15 @@ public class SwarmProtocol {
   private static final Logger LOG = LoggerFactory.getLogger(SwarmProtocol.class);
 
   private final List<SwarmNode> clusterNodes;
+  private final SwarmNode localSwarmNode;
   private final Config config;
 
   private Instant lastPingSent = Instant.now();
 
   @Inject
-  SwarmProtocol(Set<SwarmNode> clusterNodes, Config config) {
+  SwarmProtocol(Set<SwarmNode> clusterNodes, SwarmNode localSwarmNode, Config config) {
     this.clusterNodes = ImmutableList.copyOf(clusterNodes);
+    this.localSwarmNode = localSwarmNode;
     this.config = config;
   }
 
@@ -39,24 +43,34 @@ public class SwarmProtocol {
 
   }
 
-  public Optional<?> handle(SwarmTimeoutMessage timeoutMessage) {
+  public TimeoutResponse handle(SwarmTimeoutMessage timeoutMessage) {
     if (timeoutMessage.getTImestamp().isAfter(lastPingSent.plus(config.getDuration(ConfigPath.SWARM_PROTOCOL_PERIOD.getConfigPath())))) {
       int randomIndex = ThreadLocalRandom.current().nextInt(0, clusterNodes.size());
       SwarmNode randomNode = clusterNodes.get(randomIndex);
 
-//      swarmClient.sendPing(randomNode).join();
       lastPingSent = Instant.now();
+
+      return TimeoutResponse.builder()
+          .setTargetNode(randomNode)
+          .build();
     }
 
-    return Optional.empty();
+    return TimeoutResponses.empty();
   }
 
-  public void handle(PingMessage pingMessage) throws JsonProcessingException, InterruptedException {
-//    swarmClient.sendPingAck(pingMessage.getSender());
+  public PingResponse handle(PingMessage pingMessage) {
+    return PingResponse.builder()
+        .setLocalSwarmNode(localSwarmNode)
+        .setTargetNode(pingMessage.getSender())
+        .build();
   }
 
-  public void handle(PingAckMessage pingAckMessage) {
+  public PingAckResponse handle(PingAckMessage pingAckMessage) {
     LOG.info("{} has acknowledged ping", pingAckMessage.getSender());
+
+    return PingAckResponse.builder()
+        .setTimestamp(Instant.now())
+        .build();
   }
 
 }


### PR DESCRIPTION
Makes SwarmProtocol more testable by removing side-effects. Also allows multiple implementations for network/threading model.